### PR TITLE
Update BannerDetailsPage.js : use single URL for OSM tiles

### DIFF
--- a/src/components/BannerDetailsPage.js
+++ b/src/components/BannerDetailsPage.js
@@ -84,7 +84,7 @@ export default function BannerDetailsPage() {
         >
           <TileLayer
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors. This website is NOT affiliated with Bannergress in any way!'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
           <BannerMarkers
             missions={items.missions ? Object.values(items.missions) : []}


### PR DESCRIPTION
replace "{s}.tiles.openstreetmap.org" by "tiles.openstreetmap.org"