### PR TITLE
Update Map.js : use single URL for OSM tiles

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -106,7 +106,7 @@ const Map = () => {
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors. This website is NOT affiliated with Bannergress in any way!'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
 
         {banners.map((banner) => {


### PR DESCRIPTION
replace "{s}.tiles.openstreetmap.org" by "tiles.openstreetmap.org"